### PR TITLE
Add support for soft delete for all types of resources

### DIFF
--- a/app-routes.js
+++ b/app-routes.js
@@ -97,6 +97,18 @@ module.exports = (app) => {
         })
       }
 
+      actions.push((req, res, next) => {
+        if (verb === 'delete') {
+          let destroy = _.get(req, 'query.destroy', false)
+          if (destroy === 'true') {
+            destroy = true
+          } else {
+            destroy = false
+          }
+          req.query.destroy = destroy
+        }
+        next()
+      })
       actions.push(method)
       app[verb](`${config.API_VERSION}${path}`, helper.autoWrapExpress(actions))
     })

--- a/app-routes.js
+++ b/app-routes.js
@@ -99,8 +99,8 @@ module.exports = (app) => {
       }
 
       actions.push((req, res, next) => {
-        const includeSoftDeleted = req.authUser &&
-          req.query.includeSoftDeleted === 'true' &&
+        const includeSoftDeleted = req.authUser && req.authUser.roles &&
+        req.query.includeSoftDeleted === 'true' &&
           checkIfExists([constants.UserRoles.Admin], req.authUser.roles)
 
         if (!includeSoftDeleted) {

--- a/app-routes.js
+++ b/app-routes.js
@@ -7,6 +7,7 @@ const HttpStatus = require('http-status-codes')
 const helper = require('./src/common/helper')
 const errors = require('./src/common/errors')
 const routes = require('./src/routes')
+const constants = require('./app-constants')
 const authenticator = require('tc-core-library-js').middleware.jwtAuthenticator
 
 /**
@@ -61,12 +62,12 @@ module.exports = (app) => {
         next()
       })
 
+      actions.push((req, res, next) => {
+        authenticator(_.pick(config, ['AUTH_SECRET', 'VALID_ISSUERS']))(req, res, next)
+      })
+
       // Authentication and Authorization
       if (def.auth === 'jwt') {
-        actions.push((req, res, next) => {
-          authenticator(_.pick(config, ['AUTH_SECRET', 'VALID_ISSUERS']))(req, res, next)
-        })
-
         actions.push((req, res, next) => {
           if (!req.authUser) {
             return next(new errors.UnauthorizedError('Action is not allowed for invalid token'))
@@ -96,6 +97,18 @@ module.exports = (app) => {
           }
         })
       }
+
+      actions.push((req, res, next) => {
+        const includeSoftDeleted = req.authUser &&
+          req.query.includeSoftDeleted === 'true' &&
+          checkIfExists([constants.UserRoles.Admin], req.authUser.roles)
+
+        if (!includeSoftDeleted) {
+          // This will automatically handle scan calls
+          req.query.isDeleted = false
+        }
+        next()
+      })
 
       actions.push((req, res, next) => {
         if (verb === 'delete') {

--- a/app-routes.js
+++ b/app-routes.js
@@ -106,6 +106,7 @@ module.exports = (app) => {
         if (!includeSoftDeleted) {
           // This will automatically handle scan calls
           req.query.isDeleted = false
+          req.excludeSoftDeleted = true
         }
         next()
       })

--- a/app-routes.js
+++ b/app-routes.js
@@ -108,6 +108,7 @@ module.exports = (app) => {
           req.query.isDeleted = false
           req.excludeSoftDeleted = true
         }
+        delete req.query.includeSoftDeleted
         next()
       })
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -50,6 +50,7 @@ paths:
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/perPage'
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: type
           in: query
           description: Filter by type, case insensitive, partial match is used
@@ -121,6 +122,7 @@ paths:
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/perPage'
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: type
           in: query
           description: Filter by type, case insensitive, partial match is used
@@ -225,6 +227,7 @@ paths:
         - Device
       description: Retrieve the device by id
       parameters:
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: id
           in: path
           required: true
@@ -253,6 +256,7 @@ paths:
         - Device
       description: Retrieve the device head by id
       parameters:
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: id
           in: path
           required: true
@@ -380,6 +384,7 @@ paths:
       security:
         - bearer: []
       parameters:
+        - $ref: '#/parameters/destroy'
         - name: id
           in: path
           required: true
@@ -465,6 +470,7 @@ paths:
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/perPage'
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: name
           in: query
           description: Filter by name, case insensitive, partial match is used
@@ -520,6 +526,7 @@ paths:
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/perPage'
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: name
           in: query
           description: Filter by name, case insensitive, partial match is used
@@ -609,6 +616,7 @@ paths:
         - Country
       description: Retrieve the country by id
       parameters:
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: id
           in: path
           required: true
@@ -637,6 +645,7 @@ paths:
         - Country
       description: Retrieve the country head by id
       parameters:
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: id
           in: path
           required: true
@@ -764,6 +773,7 @@ paths:
       security:
         - bearer: []
       parameters:
+        - $ref: '#/parameters/destroy'
         - name: id
           in: path
           required: true
@@ -803,6 +813,7 @@ paths:
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/perPage'
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: name
           in: query
           description: Filter by name, case insensitive, partial match is used
@@ -853,6 +864,7 @@ paths:
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/perPage'
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: name
           in: query
           description: Filter by name, case insensitive, partial match is used
@@ -937,6 +949,7 @@ paths:
         - Educational Institution
       description: Retrieve the educational institution by id
       parameters:
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: id
           in: path
           required: true
@@ -965,6 +978,7 @@ paths:
         - Educational Institution
       description: Retrieve the educational institution head by id
       parameters:
+        - $ref: '#/parameters/includeSoftDeleted'
         - name: id
           in: path
           required: true
@@ -1092,6 +1106,7 @@ paths:
       security:
         - bearer: []
       parameters:
+        - $ref: '#/parameters/destroy'
         - name: id
           in: path
           required: true
@@ -1158,6 +1173,18 @@ parameters:
     type: integer
     default: 20
     maximum: 100
+  includeSoftDeleted:
+    name: includeSoftDeleted
+    in: query
+    description: Whether or not to include soft deleted items in response. (Only with Admin token)
+    type: boolean
+    default: false
+  destroy:
+    name: destroy
+    in: query
+    description: If false, soft delete the entity, else hard delete. (Only with Admin token)
+    type: boolean
+    default: false
 definitions:
   Country:
     type: object

--- a/docs/tc-lookup-api.postman_collection.json
+++ b/docs/tc-lookup-api.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4802b022-4a66-43f5-b223-cbbcfd91ad9e",
+		"_postman_id": "95dabfdf-acad-402b-9a40-3457a4dcdcd7",
 		"name": "tc-lookup-api",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -196,7 +196,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{URL}}/lookups/countries?name=Testing",
+							"raw": "{{URL}}/lookups/countries",
 							"host": [
 								"{{URL}}"
 							],
@@ -207,7 +207,71 @@
 							"query": [
 								{
 									"key": "name",
-									"value": "Testing"
+									"value": "Testing",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "list countries (include soft deleted)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/countries?includeSoftDeleted=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"countries"
+							],
+							"query": [
+								{
+									"key": "name",
+									"value": "Testing",
+									"disabled": true
+								},
+								{
+									"key": "includeSoftDeleted",
+									"value": "true"
 								}
 							]
 						}
@@ -320,6 +384,65 @@
 								"lookups",
 								"countries",
 								"{{COUNTRY_ID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get country (include soft deleted)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/countries/{{COUNTRY_ID}}?includeSoftDeleted=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"countries",
+								"{{COUNTRY_ID}}"
+							],
+							"query": [
+								{
+									"key": "includeSoftDeleted",
+									"value": "true"
+								}
 							]
 						}
 					},
@@ -877,6 +1000,62 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "delete country (destroy)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/countries/{{COUNTRY_ID}}?destroy=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"countries",
+								"{{COUNTRY_ID}}"
+							],
+							"query": [
+								{
+									"key": "destroy",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"event": [
@@ -1122,6 +1301,64 @@
 								{
 									"key": "operatingSystemVersion",
 									"value": "11"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "list devices (inlcude soft deleted)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/devices?includeSoftDeleted=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"devices"
+							],
+							"query": [
+								{
+									"key": "includeSoftDeleted",
+									"value": "true"
 								}
 							]
 						}
@@ -1442,6 +1679,65 @@
 								"lookups",
 								"devices",
 								"{{DEVICE_ID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get devices (include soft deleted)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/devices/{{DEVICE_ID}}?includeSoftDeleted=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"devices",
+								"{{DEVICE_ID}}"
+							],
+							"query": [
+								{
+									"key": "includeSoftDeleted",
+									"value": "true"
+								}
 							]
 						}
 					},
@@ -2049,6 +2345,62 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "delete device (destroy)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/devices/{{DEVICE_ID}}?destroy=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"devices",
+								"{{DEVICE_ID}}"
+							],
+							"query": [
+								{
+									"key": "destroy",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"event": [
@@ -2285,6 +2637,64 @@
 					"response": []
 				},
 				{
+					"name": "list educational institutions (include soft deleted)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/educationalInstitutions?includeSoftDeleted=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"educationalInstitutions"
+							],
+							"query": [
+								{
+									"key": "includeSoftDeleted",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "list educational institutions head",
 					"event": [
 						{
@@ -2390,6 +2800,65 @@
 								"lookups",
 								"educationalInstitutions",
 								"{{EDUCATIONAL_INSTITUTION_ID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get educational institution (include soft deleted)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{ADMIN_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/educationalInstitutions/{{EDUCATIONAL_INSTITUTION_ID}}?includeSoftDeleted=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"educationalInstitutions",
+								"{{EDUCATIONAL_INSTITUTION_ID}}"
+							],
+							"query": [
+								{
+									"key": "includeSoftDeleted",
+									"value": "true"
+								}
 							]
 						}
 					},
@@ -2593,6 +3062,62 @@
 								"lookups",
 								"educationalInstitutions",
 								"{{EDUCATIONAL_INSTITUTION_ID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete educational institution (destroy)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{M2M_UPDATE_ACCESS_TOKEN}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/educationalInstitutions/{{EDUCATIONAL_INSTITUTION_ID}}?destroy=true",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"educationalInstitutions",
+								"{{EDUCATIONAL_INSTITUTION_ID}}"
+							],
+							"query": [
+								{
+									"key": "destroy",
+									"value": "true"
+								}
 							]
 						}
 					},

--- a/resources/countries.json
+++ b/resources/countries.json
@@ -6,6 +6,12 @@
         "isDeleted": false
     },
     {
+        "name": "Spain",
+        "countryFlag": "Spain Flag",
+        "countryCode": "004",
+        "isDeleted": true
+    },
+    {
         "name": "England",
         "countryFlag": "England Flag",
         "countryCode": "007",

--- a/resources/countries.json
+++ b/resources/countries.json
@@ -2,12 +2,14 @@
     {
         "name": "Italy",
         "countryFlag": "Italy Flag",
-        "countryCode": "005"
+        "countryCode": "005",
+        "isDeleted": false
     },
     {
         "name": "England",
         "countryFlag": "England Flag",
-        "countryCode": "007"
+        "countryCode": "007",
+        "isDeleted": false
     }
 ]
 

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -9,6 +9,14 @@
     },
     {
         "type": "Mobile",
+        "manufacturer": "Apple",
+        "model": "iPhone XS",
+        "operatingSystem": "iOS",
+        "operatingSystemVersion": "10.14",
+        "isDeleted": true
+    },
+    {
+        "type": "Mobile",
         "manufacturer": "Samsung",
         "model": "Note8",
         "operatingSystem": "Android",

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -4,13 +4,15 @@
         "manufacturer": "Apple",
         "model": "Macbook Pro",
         "operatingSystem": "OSX",
-        "operatingSystemVersion": "10.14"
+        "operatingSystemVersion": "10.14",
+        "isDeleted": false
     },
     {
         "type": "Mobile",
         "manufacturer": "Samsung",
         "model": "Note8",
         "operatingSystem": "Android",
-        "operatingSystemVersion": "10.x"
+        "operatingSystemVersion": "10.x",
+        "isDeleted": false
     }
 ]

--- a/resources/educational_institutions.json
+++ b/resources/educational_institutions.json
@@ -1,9 +1,11 @@
 [
     {
-        "name": "Educational Insitution 1"
+        "name": "Educational Insitution 1",
+        "isDeleted": false
     },
     {
-        "name": "Educational Insitution 2"
+        "name": "Educational Insitution 2",
+        "isDeleted": false
     }
 ]
 

--- a/resources/educational_institutions.json
+++ b/resources/educational_institutions.json
@@ -5,6 +5,10 @@
     },
     {
         "name": "Educational Insitution 2",
+        "isDeleted": true
+    },
+    {
+        "name": "Educational Insitution 3",
         "isDeleted": false
     }
 ]

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -25,6 +25,18 @@ AWS.config.update({
   region: config.AMAZON.AWS_REGION
 })
 
+const MODEL_TO_ES_INDEX_MAP = {
+  [config.AMAZON.DYNAMODB_DEVICE_TABLE]: config.ES.DEVICE_INDEX,
+  [config.AMAZON.DYNAMODB_COUNTRY_TABLE]: config.ES.COUNTRY_INDEX,
+  [config.AMAZON.DYNAMODB_EDUCATIONAL_INSTITUTION_TABLE]: config.ES.EDUCATIONAL_INSTITUTION_INDEX
+}
+
+const MODEL_TO_ES_TYPE_MAP = {
+  [config.AMAZON.DYNAMODB_DEVICE_TABLE]: config.ES.DEVICE_TYPE,
+  [config.AMAZON.DYNAMODB_COUNTRY_TABLE]: config.ES.COUNTRY_TYPE,
+  [config.AMAZON.DYNAMODB_EDUCATIONAL_INSTITUTION_TABLE]: config.ES.EDUCATIONAL_INSTITUTION_TYPE
+}
+
 /**
  * Wrap async function to standard express function
  * @param {Function} fn the async function
@@ -112,6 +124,10 @@ async function deleteTable (tableName) {
   })
 }
 
+function getNotFoundError (modelName, id) {
+  return new errors.NotFoundError(`${modelName} with id: ${id} doesn't exist`)
+}
+
 /**
  * Get Data by model id
  * @param {String} modelName The dynamoose model name
@@ -126,7 +142,7 @@ async function getById (modelName, id) {
       } else if (result.length > 0) {
         resolve(result[0])
       } else {
-        reject(new errors.NotFoundError(`${modelName} with id: ${id} doesn't exist`))
+        reject(getNotFoundError(modelName, id))
       }
     })
   })
@@ -272,6 +288,32 @@ function getESClient () {
   return esClient
 }
 
+async function getEntity (modelName, id, excludeSoftDeleted) {
+  let entity = null
+  // first try to get from ES
+  try {
+    const client = getESClient()
+    const sourceParams = {
+      index: MODEL_TO_ES_INDEX_MAP[modelName],
+      type: MODEL_TO_ES_TYPE_MAP[modelName],
+      id
+    }
+    entity = await client.getSource(sourceParams)
+  } catch (e) {
+    // log and ignore
+    logger.logFullError(e)
+  }
+
+  // then try to get from DB
+  if (!entity) {
+    entity = await getById(modelName, id)
+  }
+  if (excludeSoftDeleted && _.get(entity, 'isDeleted') === true) {
+    throw new errors.NotFoundError(getNotFoundError(modelName, id))
+  }
+  return entity
+}
+
 /**
  * Create Elasticsearch index, it will be deleted and re-created if present.
  * @param {String} indexName the ES index name
@@ -387,6 +429,7 @@ module.exports = {
   createTable,
   deleteTable,
   getById,
+  getEntity,
   create,
   update,
   remove,

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -139,6 +139,7 @@ async function getById (modelName, id) {
  * @returns created entity
  */
 async function create (modelName, data) {
+  data.isDeleted = false
   return new Promise((resolve, reject) => {
     const dbItem = new models[modelName](data)
     dbItem.save((err) => {
@@ -172,11 +173,19 @@ async function update (dbItem, data) {
   })
 }
 
+async function remove (dbItem, destroy) {
+  if (destroy) {
+    return deleteItem(dbItem)
+  } else {
+    return update(dbItem, { isDeleted: true })
+  }
+}
+
 /**
- * Remove item in database
+ * Delete item in database
  * @param {Object} dbItem The Dynamo database item to remove
  */
-async function remove (dbItem) {
+async function deleteItem (dbItem) {
   return new Promise((resolve, reject) => {
     dbItem.delete((err) => {
       if (err) {

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -155,7 +155,9 @@ async function getById (modelName, id) {
  * @returns created entity
  */
 async function create (modelName, data) {
-  data.isDeleted = false
+  if (_.isNil(data.isDeleted)) {
+    data.isDeleted = false
+  }
   return new Promise((resolve, reject) => {
     const dbItem = new models[modelName](data)
     dbItem.save((err) => {
@@ -321,6 +323,7 @@ async function getEntity (modelName, id, excludeSoftDeleted) {
  * @param {Array} fields the indexed fields
  */
 async function createESIndex (indexName, typeName, fields) {
+  fields.push('isDeleted')
   const client = getESClient()
   // delete index if present
   try {

--- a/src/controllers/CountryController.js
+++ b/src/controllers/CountryController.js
@@ -12,6 +12,9 @@ const helper = require('../common/helper')
  */
 async function list (req, res) {
   const result = await service.list(req.query)
+  result.result.forEach(entity => {
+    delete entity.isDeleted
+  })
   helper.setResHeaders(req, res, result)
   res.send(result.result)
 }
@@ -34,6 +37,7 @@ async function listHead (req, res) {
  */
 async function create (req, res) {
   const result = await service.create(req.body)
+  delete result.isDeleted
   res.status(HttpStatus.CREATED).send(result)
 }
 
@@ -44,6 +48,7 @@ async function create (req, res) {
  */
 async function getEntity (req, res) {
   const result = await service.getEntity(req.params.id, req.excludeSoftDeleted)
+  delete result.isDeleted
   res.send(result)
 }
 
@@ -64,6 +69,7 @@ async function getEntityHead (req, res) {
  */
 async function update (req, res) {
   const result = await service.update(req.params.id, req.body)
+  delete result.isDeleted
   res.send(result)
 }
 
@@ -74,6 +80,7 @@ async function update (req, res) {
  */
 async function partiallyUpdate (req, res) {
   const result = await service.partiallyUpdate(req.params.id, req.body)
+  delete result.isDeleted
   res.send(result)
 }
 

--- a/src/controllers/CountryController.js
+++ b/src/controllers/CountryController.js
@@ -43,7 +43,7 @@ async function create (req, res) {
  * @param {Object} res the response
  */
 async function getEntity (req, res) {
-  const result = await service.getEntity(req.params.id)
+  const result = await service.getEntity(req.params.id, req.excludeSoftDeleted)
   res.send(result)
 }
 
@@ -53,7 +53,7 @@ async function getEntity (req, res) {
  * @param {Object} res the response
  */
 async function getEntityHead (req, res) {
-  await service.getEntity(req.params.id)
+  await service.getEntity(req.params.id, req.excludeSoftDeleted)
   res.end()
 }
 

--- a/src/controllers/CountryController.js
+++ b/src/controllers/CountryController.js
@@ -83,7 +83,7 @@ async function partiallyUpdate (req, res) {
  * @param {Object} res the response
  */
 async function remove (req, res) {
-  await service.remove(req.params.id)
+  await service.remove(req.params.id, req.query.destroy)
   res.status(HttpStatus.NO_CONTENT).end()
 }
 

--- a/src/controllers/DeviceController.js
+++ b/src/controllers/DeviceController.js
@@ -12,6 +12,9 @@ const helper = require('../common/helper')
  */
 async function list (req, res) {
   const result = await service.list(req.query)
+  result.result.forEach(entity => {
+    delete entity.isDeleted
+  })
   helper.setResHeaders(req, res, result)
   res.send(result.result)
 }
@@ -34,6 +37,7 @@ async function listHead (req, res) {
  */
 async function create (req, res) {
   const result = await service.create(req.body)
+  delete result.isDeleted
   res.status(HttpStatus.CREATED).send(result)
 }
 
@@ -44,6 +48,7 @@ async function create (req, res) {
  */
 async function getEntity (req, res) {
   const result = await service.getEntity(req.params.id, req.excludeSoftDeleted)
+  delete result.isDeleted
   res.send(result)
 }
 
@@ -64,6 +69,7 @@ async function getEntityHead (req, res) {
  */
 async function update (req, res) {
   const result = await service.update(req.params.id, req.body)
+  delete result.isDeleted
   res.send(result)
 }
 
@@ -74,6 +80,7 @@ async function update (req, res) {
  */
 async function partiallyUpdate (req, res) {
   const result = await service.partiallyUpdate(req.params.id, req.body)
+  delete result.isDeleted
   res.send(result)
 }
 

--- a/src/controllers/DeviceController.js
+++ b/src/controllers/DeviceController.js
@@ -43,7 +43,7 @@ async function create (req, res) {
  * @param {Object} res the response
  */
 async function getEntity (req, res) {
-  const result = await service.getEntity(req.params.id)
+  const result = await service.getEntity(req.params.id, req.excludeSoftDeleted)
   res.send(result)
 }
 
@@ -53,7 +53,7 @@ async function getEntity (req, res) {
  * @param {Object} res the response
  */
 async function getEntityHead (req, res) {
-  await service.getEntity(req.params.id)
+  await service.getEntity(req.params.id, req.excludeSoftDeleted)
   res.end()
 }
 

--- a/src/controllers/DeviceController.js
+++ b/src/controllers/DeviceController.js
@@ -83,7 +83,7 @@ async function partiallyUpdate (req, res) {
  * @param {Object} res the response
  */
 async function remove (req, res) {
-  await service.remove(req.params.id)
+  await service.remove(req.params.id, req.query.destroy)
   res.status(HttpStatus.NO_CONTENT).end()
 }
 

--- a/src/controllers/EducationalInstitutionController.js
+++ b/src/controllers/EducationalInstitutionController.js
@@ -12,6 +12,9 @@ const helper = require('../common/helper')
  */
 async function list (req, res) {
   const result = await service.list(req.query)
+  result.result.forEach(entity => {
+    delete entity.isDeleted
+  })
   helper.setResHeaders(req, res, result)
   res.send(result.result)
 }
@@ -34,6 +37,7 @@ async function listHead (req, res) {
  */
 async function create (req, res) {
   const result = await service.create(req.body)
+  delete result.isDeleted
   res.status(HttpStatus.CREATED).send(result)
 }
 
@@ -44,6 +48,7 @@ async function create (req, res) {
  */
 async function getEntity (req, res) {
   const result = await service.getEntity(req.params.id, req.excludeSoftDeleted)
+  delete result.isDeleted
   res.send(result)
 }
 
@@ -64,6 +69,7 @@ async function getEntityHead (req, res) {
  */
 async function update (req, res) {
   const result = await service.update(req.params.id, req.body)
+  delete result.isDeleted
   res.send(result)
 }
 
@@ -74,6 +80,7 @@ async function update (req, res) {
  */
 async function partiallyUpdate (req, res) {
   const result = await service.partiallyUpdate(req.params.id, req.body)
+  delete result.isDeleted
   res.send(result)
 }
 

--- a/src/controllers/EducationalInstitutionController.js
+++ b/src/controllers/EducationalInstitutionController.js
@@ -43,7 +43,7 @@ async function create (req, res) {
  * @param {Object} res the response
  */
 async function getEntity (req, res) {
-  const result = await service.getEntity(req.params.id)
+  const result = await service.getEntity(req.params.id, req.excludeSoftDeleted)
   res.send(result)
 }
 
@@ -53,7 +53,7 @@ async function getEntity (req, res) {
  * @param {Object} res the response
  */
 async function getEntityHead (req, res) {
-  await service.getEntity(req.params.id)
+  await service.getEntity(req.params.id, req.excludeSoftDeleted)
   res.end()
 }
 

--- a/src/controllers/EducationalInstitutionController.js
+++ b/src/controllers/EducationalInstitutionController.js
@@ -83,7 +83,7 @@ async function partiallyUpdate (req, res) {
  * @param {Object} res the response
  */
 async function remove (req, res) {
-  await service.remove(req.params.id)
+  await service.remove(req.params.id, req.query.destroy)
   res.status(HttpStatus.NO_CONTENT).end()
 }
 

--- a/src/models/Country.js
+++ b/src/models/Country.js
@@ -23,6 +23,10 @@ const schema = new Schema({
   countryCode: {
     type: String,
     required: true
+  },
+  isDeleted: {
+    type: Boolean,
+    default: false,
   }
 },
 {

--- a/src/models/Device.js
+++ b/src/models/Device.js
@@ -31,6 +31,10 @@ const schema = new Schema({
   operatingSystemVersion: {
     type: String,
     required: false
+  },
+  isDeleted: {
+    type: Boolean,
+    default: false,
   }
 },
 {

--- a/src/models/EducationalInstitution.js
+++ b/src/models/EducationalInstitution.js
@@ -15,6 +15,10 @@ const schema = new Schema({
   name: {
     type: String,
     required: true
+  },
+  isDeleted: {
+    type: Boolean,
+    default: false,
   }
 },
 {

--- a/src/services/CountryService.js
+++ b/src/services/CountryService.js
@@ -105,7 +105,8 @@ list.schema = {
     perPage: Joi.perPage(),
     name: Joi.string(),
     countryFlag: Joi.string(),
-    countryCode: Joi.string()
+    countryCode: Joi.string(),
+    isDeleted: Joi.boolean()
   })
 }
 
@@ -119,7 +120,8 @@ async function getEntity (id, excludeSoftDeleted) {
 }
 
 getEntity.schema = {
-  id: Joi.id()
+  id: Joi.id(),
+  excludeSoftDeleted: Joi.boolean()
 }
 
 /**
@@ -218,7 +220,8 @@ async function remove (id, destroy) {
 }
 
 remove.schema = {
-  id: Joi.id()
+  id: Joi.id(),
+  destroy: Joi.boolean()
 }
 
 module.exports = {

--- a/src/services/CountryService.js
+++ b/src/services/CountryService.js
@@ -111,21 +111,8 @@ list.schema = {
  * @param {String} id the country id
  * @returns {Object} the country of given id
  */
-async function getEntity (id) {
-  // first try to get from ES
-  try {
-    return await esClient.getSource({
-      index: config.ES.COUNTRY_INDEX,
-      type: config.ES.COUNTRY_TYPE,
-      id
-    })
-  } catch (e) {
-    // log and ignore
-    logger.logFullError(e)
-  }
-
-  // then try to get from DB
-  return helper.getById(config.AMAZON.DYNAMODB_COUNTRY_TABLE, id)
+async function getEntity (id, excludeSoftDeleted) {
+  return helper.getEntity(config.AMAZON.DYNAMODB_COUNTRY_TABLE, id, excludeSoftDeleted)
 }
 
 getEntity.schema = {

--- a/src/services/CountryService.js
+++ b/src/services/CountryService.js
@@ -52,6 +52,14 @@ async function listES (criteria) {
     })
   }
 
+  if (!_.isNil(criteria.isDeleted)) {
+    esQuery.body.query.bool.must.push({
+      term: {
+        isDeleted: criteria.isDeleted
+      }
+    })
+  }
+
   // Search with constructed query
   const docs = await esClient.search(esQuery)
   // Extract data from hits

--- a/src/services/CountryService.js
+++ b/src/services/CountryService.js
@@ -218,10 +218,10 @@ update.schema = {
  * Remove country.
  * @param {String} id the country id to remove
  */
-async function remove (id) {
+async function remove (id, destroy) {
   // remove data in DB
   const country = await helper.getById(config.AMAZON.DYNAMODB_COUNTRY_TABLE, id)
-  await helper.remove(country)
+  await helper.remove(country, destroy)
 
   // Send Kafka message using bus api
   await helper.postEvent(config.LOOKUP_DELETE_TOPIC, { resource: Resources.Country, id })

--- a/src/services/CountryService.js
+++ b/src/services/CountryService.js
@@ -89,6 +89,9 @@ async function list (criteria) {
   if (criteria.countryCode) {
     options.countryCode = { eq: criteria.countryCode }
   }
+  if (!_.isNil(criteria.isDeleted)) {
+    options.isDeleted = { eq: criteria.isDeleted }
+  }
   // ignore pagination, scan all matched records
   result = await helper.scan(config.AMAZON.DYNAMODB_COUNTRY_TABLE, options)
   // return fromDB:true to indicate it is got from db,

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -274,10 +274,10 @@ update.schema = {
  * Remove device.
  * @param {String} id the device id to remove
  */
-async function remove (id) {
+async function remove (id, destroy) {
   // remove data in DB
   const device = await helper.getById(config.AMAZON.DYNAMODB_DEVICE_TABLE, id)
-  await helper.remove(device)
+  await helper.remove(device, destroy)
 
   // Send Kafka message using bus api
   await helper.postEvent(config.LOOKUP_DELETE_TOPIC, { resource: Resources.Device, id })

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -145,7 +145,8 @@ list.schema = {
     manufacturer: Joi.string(),
     model: Joi.string(),
     operatingSystem: Joi.string(),
-    operatingSystemVersion: Joi.string()
+    operatingSystemVersion: Joi.string(),
+    isDeleted: Joi.boolean()
   })
 }
 
@@ -159,7 +160,8 @@ async function getEntity (id, excludeSoftDeleted) {
 }
 
 getEntity.schema = {
-  id: Joi.id()
+  id: Joi.id(),
+  excludeSoftDeleted: Joi.boolean()
 }
 
 /**
@@ -274,7 +276,8 @@ async function remove (id, destroy) {
 }
 
 remove.schema = {
-  id: Joi.id()
+  id: Joi.id(),
+  destroy: Joi.boolean()
 }
 
 /**

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -81,6 +81,14 @@ async function listES (criteria) {
     })
   }
 
+  if (!_.isNil(criteria.isDeleted)) {
+    esQuery.body.query.bool.must.push({
+      term: {
+        isDeleted: criteria.isDeleted
+      }
+    })
+  }
+
   // Search with constructed query
   const docs = await esClient.search(esQuery)
   // Extract data from hits

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -151,21 +151,8 @@ list.schema = {
  * @param {String} id the device id
  * @returns {Object} the device of given id
  */
-async function getEntity (id) {
-  // first try to get from ES
-  try {
-    return await esClient.getSource({
-      index: config.ES.DEVICE_INDEX,
-      type: config.ES.DEVICE_TYPE,
-      id
-    })
-  } catch (e) {
-    // log and ignore
-    logger.logFullError(e)
-  }
-
-  // then try to get from DB
-  return helper.getById(config.AMAZON.DYNAMODB_DEVICE_TABLE, id)
+async function getEntity (id, excludeSoftDeleted) {
+  return helper.getEntity(config.AMAZON.DYNAMODB_DEVICE_TABLE, id, excludeSoftDeleted)
 }
 
 getEntity.schema = {

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -127,6 +127,9 @@ async function list (criteria) {
   if (criteria.operatingSystemVersion) {
     options.operatingSystemVersion = { eq: criteria.operatingSystemVersion }
   }
+  if (!_.isNil(criteria.isDeleted)) {
+    options.isDeleted = { eq: criteria.isDeleted }
+  }
   // ignore pagination, scan all matched records
   result = await helper.scan(config.AMAZON.DYNAMODB_DEVICE_TABLE, options)
   // return fromDB:true to indicate it is got from db,

--- a/src/services/EducationalInstitutionService.js
+++ b/src/services/EducationalInstitutionService.js
@@ -44,6 +44,14 @@ async function listES (criteria) {
     })
   }
 
+  if (!_.isNil(criteria.isDeleted)) {
+    esQuery.body.query.bool.must.push({
+      term: {
+        isDeleted: criteria.isDeleted
+      }
+    })
+  }
+
   // Search with constructed query
   const docs = await esClient.search(esQuery)
   // Extract data from hits

--- a/src/services/EducationalInstitutionService.js
+++ b/src/services/EducationalInstitutionService.js
@@ -92,7 +92,8 @@ list.schema = {
   criteria: Joi.object().keys({
     page: Joi.page(),
     perPage: Joi.perPage(),
-    name: Joi.string()
+    name: Joi.string(),
+    isDeleted: Joi.boolean()
   })
 }
 
@@ -106,7 +107,8 @@ async function getEntity (id, excludeSoftDeleted) {
 }
 
 getEntity.schema = {
-  id: Joi.id()
+  id: Joi.id(),
+  excludeSoftDeleted: Joi.boolean()
 }
 
 /**
@@ -196,7 +198,8 @@ async function remove (id, destroy) {
 }
 
 remove.schema = {
-  id: Joi.id()
+  id: Joi.id(),
+  destroy: Joi.boolean()
 }
 
 module.exports = {

--- a/src/services/EducationalInstitutionService.js
+++ b/src/services/EducationalInstitutionService.js
@@ -100,21 +100,8 @@ list.schema = {
  * @param {String} id the educational institution id
  * @returns {Object} the educational institution of given id
  */
-async function getEntity (id) {
-  // first try to get from ES
-  try {
-    return await esClient.getSource({
-      index: config.ES.EDUCATIONAL_INSTITUTION_INDEX,
-      type: config.ES.EDUCATIONAL_INSTITUTION_TYPE,
-      id
-    })
-  } catch (e) {
-    // log and ignore
-    logger.logFullError(e)
-  }
-
-  // then try to get from DB
-  return helper.getById(config.AMAZON.DYNAMODB_EDUCATIONAL_INSTITUTION_TABLE, id)
+async function getEntity (id, excludeSoftDeleted) {
+  return helper.getEntity(config.AMAZON.DYNAMODB_EDUCATIONAL_INSTITUTION_TABLE, id, excludeSoftDeleted)
 }
 
 getEntity.schema = {

--- a/src/services/EducationalInstitutionService.js
+++ b/src/services/EducationalInstitutionService.js
@@ -74,11 +74,12 @@ async function list (criteria) {
   }
 
   // then try to get from DB
-  let options
+  const options = {}
   if (criteria.name) {
-    options = {
-      name: { eq: criteria.name }
-    }
+    options.name = { eq: criteria.name }
+  }
+  if (!_.isNil(criteria.isDeleted)) {
+    options.isDeleted = { eq: criteria.isDeleted }
   }
   // ignore pagination, scan all matched records
   result = await helper.scan(config.AMAZON.DYNAMODB_EDUCATIONAL_INSTITUTION_TABLE, options)

--- a/src/services/EducationalInstitutionService.js
+++ b/src/services/EducationalInstitutionService.js
@@ -198,10 +198,10 @@ update.schema = {
  * Remove educational institution.
  * @param {String} id the educational institution id to remove
  */
-async function remove (id) {
+async function remove (id, destroy) {
   // remove data in DB
   const ei = await helper.getById(config.AMAZON.DYNAMODB_EDUCATIONAL_INSTITUTION_TABLE, id)
-  await helper.remove(ei)
+  await helper.remove(ei, destroy)
 
   // Send Kafka message using bus api
   await helper.postEvent(config.LOOKUP_DELETE_TOPIC, { resource: Resources.EducationalInstitution, id })


### PR DESCRIPTION
Resolve #13 

- [x] Update the model of all resources (countries, educational institutions and devices) to have a boolean attribute named isDeleted that defaults to false.
- [x] DELETE /v5/lookups/{resource}/{resourceId} will do a soft delete. It is basically a PATCH request, where the request body is { "isDeleted": true }
- [x] DELETE /v5/lookups/{resource}/{resourceId}?destroy=true will do a hard delete. This is basically the current DELETE api, but improved to support a destroy query parameter. This will delete the record from dynamodb and publish to the bus api.
- [x] Allow admin users to list/get soft-deleted entities if `includeSoftDeleted=true` is provided as query param.
- [x] Do not show the `isDeleted` field in the entities returned in the response. 