### PR TITLE
Add distinct device models endpoint

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -462,6 +462,12 @@ paths:
         - Device
       description: |
         List distinct device models.
+      parameters:
+        - name: type
+          in: query
+          description: Filter by device type, case insensitive, partial match is used
+          required: false
+          type: string
 
       responses:
         '200':

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -456,6 +456,24 @@ paths:
           description: Server error
           schema:
             $ref: '#/definitions/ErrorModel'
+  '/lookups/devices/models':
+    get:
+      tags:
+        - Device
+      description: |
+        List distinct device models.
+
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            items:
+              type: string
+        '500':
+          description: Server error
+          schema:
+            $ref: '#/definitions/ErrorModel'
   '/lookups/countries':
     get:
       tags:

--- a/docs/tc-lookup-api.postman_collection.json
+++ b/docs/tc-lookup-api.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "4802b022-4a66-43f5-b223-cbbcfd91ad9e",
-		"name": "tc-lookup-api",
+		"_postman_id": "b3587de7-1b41-4422-bb81-0f18a4efd0d3",
+		"name": "tc-lookup-api copy",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -1230,6 +1230,55 @@
 								"lookups",
 								"devices",
 								"types"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get device models",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fb283d16-ca1b-4b47-8e95-ed76324d2174",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{URL}}/lookups/devices/models",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"lookups",
+								"devices",
+								"models"
 							]
 						}
 					},

--- a/src/controllers/DeviceController.js
+++ b/src/controllers/DeviceController.js
@@ -107,6 +107,16 @@ async function getManufacturers (req, res) {
   res.send(result)
 }
 
+/**
+ * Get distinct device models
+ * @param {Object} req the request
+ * @param {Object} res the response
+ */
+async function getDeviceModels (req, res) {
+  const result = await service.getDeviceModels()
+  res.send(result)
+}
+
 module.exports = {
   list,
   listHead,
@@ -117,5 +127,6 @@ module.exports = {
   partiallyUpdate,
   remove,
   getTypes,
-  getManufacturers
+  getManufacturers,
+  getDeviceModels
 }

--- a/src/controllers/DeviceController.js
+++ b/src/controllers/DeviceController.js
@@ -113,7 +113,7 @@ async function getManufacturers (req, res) {
  * @param {Object} res the response
  */
 async function getDeviceModels (req, res) {
-  const result = await service.getDeviceModels()
+  const result = await service.getDeviceModels(req.query)
   res.send(result)
 }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -146,6 +146,13 @@ module.exports = {
       // any role / scope is allowed
     }
   },
+  '/lookups/devices/models': {
+    get: {
+      controller: 'DeviceController',
+      method: 'getDeviceModels'
+      // any role / scope is allowed
+    }
+  },
   '/lookups/devices/:id': {
     get: {
       controller: 'DeviceController',

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -351,6 +351,20 @@ getManufacturers.schema = {
   }).required()
 }
 
+/**
+ * Get distinct device models.
+ * @returns {Array} the distinct device models
+ */
+async function getDeviceModels () {
+  const result = []
+  await iterateDevices({}, (device) => {
+    if (!_.includes(result, device.model)) {
+      result.push(device.model)
+    }
+  })
+  return result
+}
+
 module.exports = {
   list,
   getEntity,
@@ -359,7 +373,8 @@ module.exports = {
   update,
   remove,
   getTypes,
-  getManufacturers
+  getManufacturers,
+  getDeviceModels
 }
 
 logger.buildService(module.exports)

--- a/src/services/DeviceService.js
+++ b/src/services/DeviceService.js
@@ -353,16 +353,23 @@ getManufacturers.schema = {
 
 /**
  * Get distinct device models.
+ * @param {Object} criteria the search criteria
  * @returns {Array} the distinct device models
  */
-async function getDeviceModels () {
+async function getDeviceModels (criteria) {
   const result = []
-  await iterateDevices({}, (device) => {
+  await iterateDevices(criteria, (device) => {
     if (!_.includes(result, device.model)) {
       result.push(device.model)
     }
   })
   return result
+}
+
+getDeviceModels.schema = {
+  criteria: Joi.object().keys({
+    type: Joi.string()
+  })
 }
 
 module.exports = {


### PR DESCRIPTION
Resolves #21 

- [x] Add endpoint `GET /lookups/devices/models` to list all distinct device models.
- [x] Allow results to be filtered by `device.type`